### PR TITLE
Create msd file format

### DIFF
--- a/packages/api/src/contract.ts
+++ b/packages/api/src/contract.ts
@@ -40,11 +40,14 @@ export const postTranscodeBodySchema = z.object({
 
 export const postPackageBodySchema = z.object({
   assetId: z.string(),
-  segmentSize: z.number().optional().openapi({
-    default: 4,
-    description:
-      "Segment size, must be equal or a multiple of the segmentSize defined in transcode.",
-  }),
+  segmentSize: z
+    .number()
+    .optional()
+    .openapi({
+      description:
+        "Segment size. When defined, must be equal or a multiple of the segmentSize defined in transcode. " +
+        "When not defined, will take the original segmentSize from transcode.",
+    }),
   tag: z.string().optional().openapi({
     description: "An arbitrary tag, used to group jobs.",
   }),

--- a/packages/api/src/s3.ts
+++ b/packages/api/src/s3.ts
@@ -89,9 +89,6 @@ export async function getStorageFile(path: string): Promise<FileDto> {
 
 function canFilePreview(name: string): boolean {
   return (
-    name.endsWith(".vtt") ||
-    name.endsWith(".m3u8") ||
-    name.endsWith(".json") ||
-    name.endsWith(".msd")
+    name.endsWith(".vtt") || name.endsWith(".m3u8") || name.endsWith(".json")
   );
 }

--- a/packages/api/src/s3.ts
+++ b/packages/api/src/s3.ts
@@ -89,6 +89,9 @@ export async function getStorageFile(path: string): Promise<FileDto> {
 
 function canFilePreview(name: string): boolean {
   return (
-    name.endsWith(".vtt") || name.endsWith(".m3u8") || name.endsWith(".json")
+    name.endsWith(".vtt") ||
+    name.endsWith(".m3u8") ||
+    name.endsWith(".json") ||
+    name.endsWith(".msd")
   );
 }

--- a/packages/artisan/src/consumer/workers/transcode.ts
+++ b/packages/artisan/src/consumer/workers/transcode.ts
@@ -27,7 +27,7 @@ export default async function (job: Job<TranscodeData, TranscodeResult>) {
 
   const childrenValues = await fakeJob.getChildrenValues();
 
-  const meta = Object.entries(childrenValues).reduce<Record<string, Stream>>(
+  const streams = Object.entries(childrenValues).reduce<Record<string, Stream>>(
     (acc, [key, value]) => {
       if (key.startsWith("bull:ffmpeg")) {
         const ffmpegResult: FfmpegResult = value;
@@ -38,11 +38,18 @@ export default async function (job: Job<TranscodeData, TranscodeResult>) {
     {},
   );
 
-  await job.log(`Writing meta.json (${JSON.stringify(meta)})`);
+  // Media Source Definition
+  const mediaSourceDefinition = {
+    version: 1,
+    streams,
+    segmentSize: params.segmentSize,
+  };
+
+  await job.log(`Writing file.msd (${JSON.stringify(mediaSourceDefinition)})`);
 
   await uploadJsonFile(
-    `transcode/${params.assetId}/meta.json`,
-    JSON.stringify(meta, null, 2),
+    `transcode/${params.assetId}/file.msd`,
+    JSON.stringify(mediaSourceDefinition, null, 2),
   );
 
   if (params.packageAfter) {

--- a/packages/artisan/src/producer/index.ts
+++ b/packages/artisan/src/producer/index.ts
@@ -137,7 +137,7 @@ type AddPackageJobData = {
 
 export async function addPackageJob({
   assetId,
-  segmentSize = 4,
+  segmentSize,
   name = "hls",
   tag,
 }: AddPackageJobData) {


### PR DESCRIPTION
The transcode result can now be refered to as an "msd" file. This is an intermediary format that contains all necessary info about the transcode result.

We used to create a `meta.json` file, but it did not contain all of the info and was not versioned. An `msd` (Media Source Definition), or if you want to giggle, "Mixwave Source Definition" is now the official format of a transcode result.

An `msd` file is meaningless on its own, it serves no purpose besides being packaged further on into known stream protocols such as HLS.